### PR TITLE
优化外置代理 MKV 开播等待，保留蓝光菜单 DV 与选曲修复

### DIFF
--- a/.github/workflows/build-mpv-v100-parity.yml
+++ b/.github/workflows/build-mpv-v100-parity.yml
@@ -2,8 +2,8 @@ name: "Build V1.0.0 main and Atmos parity candidates"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [codex/bluray-menu-dv-20260912]
+  pull_request:
+    branches: [codex/v100-core-parity-20260907]
     paths:
       - .github/workflows/build-mpv-v100-parity.yml
       - build/atmos/**

--- a/.github/workflows/build-mpv-v100-parity.yml
+++ b/.github/workflows/build-mpv-v100-parity.yml
@@ -3,7 +3,7 @@ name: "Build V1.0.0 main and Atmos parity candidates"
 on:
   workflow_dispatch:
   push:
-    branches: [codex/v100-core-parity-20260907]
+    branches: [codex/bluray-menu-dv-20260912]
     paths:
       - .github/workflows/build-mpv-v100-parity.yml
       - build/atmos/**
@@ -915,6 +915,14 @@ jobs:
           fi
           cp -a "$built_dir" release/
           7z a -m0=lzma2 -mx=9 -ms=on "release/$(basename "$built_dir").7z" "$built_dir"/* -x!*.7z
+
+      - name: Verify menu command termination and late enhancement selection
+        if: steps.build.outcome == 'success'
+        run: |
+          python3 build/bluray-menu/tests/verify-menu-dv-state.py \
+            --mpv-source winbuild/mpv-winbuild-cmake/src_packages/mpv \
+            --bd-source winbuild/mpv-winbuild-cmake/src_packages/libbluray \
+            --work menu-dv-state-verification
 
       - name: Preserve dependency cache after a failed build
         if: steps.build.outcome == 'failure'

--- a/.github/workflows/build-mpv-v100-parity.yml
+++ b/.github/workflows/build-mpv-v100-parity.yml
@@ -921,7 +921,7 @@ jobs:
         run: |
           python3 build/bluray-menu/tests/verify-menu-dv-state.py \
             --mpv-source winbuild/mpv-winbuild-cmake/src_packages/mpv \
-            --bd-source winbuild/mpv-winbuild-cmake/src_packages/libbluray \
+            --bd-source winbuild/mpv-winbuild-cmake/build64/menu-dv-bd-source \
             --work menu-dv-state-verification
 
       - name: Preserve dependency cache after a failed build

--- a/.github/workflows/build-orender-viewport.yml
+++ b/.github/workflows/build-orender-viewport.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Apply viewport patch and locked dependencies
         shell: pwsh
         run: |
+          $source = 'omniphony-renderer/orender_engine/src/overlay.rs'
+          $text = [IO.File]::ReadAllText($source).Replace("`r`n", "`n")
+          [IO.File]::WriteAllText($source, $text, [Text.UTF8Encoding]::new($false))
           git apply --check ci-config/build/feedback/patches/orender-viewport-safe-area.patch
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           git apply ci-config/build/feedback/patches/orender-viewport-safe-area.patch

--- a/.github/workflows/build-orender-viewport.yml
+++ b/.github/workflows/build-orender-viewport.yml
@@ -1,0 +1,53 @@
+name: Build Atmos viewport candidate
+on:
+  push:
+    branches: [codex/v100-core-parity-20260907]
+    paths:
+      - .github/workflows/build-orender-viewport.yml
+      - build/feedback/patches/orender-viewport-safe-area.patch
+permissions:
+  contents: read
+jobs:
+  renderer:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: mgth/Omniphony
+          ref: f9a79721af64ad9c39042d4deded158b568fc598
+      - uses: actions/checkout@v6
+        with:
+          path: ci-config
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Apply viewport patch and locked dependencies
+        shell: pwsh
+        run: |
+          git apply --check ci-config/build/feedback/patches/orender-viewport-safe-area.patch
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          git apply ci-config/build/feedback/patches/orender-viewport-safe-area.patch
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Copy-Item ci-config/build/atmos/parity/orender-Cargo.lock omniphony-renderer/Cargo.lock
+      - name: Verify spatial geometry, state and heatmap
+        working-directory: omniphony-renderer
+        run: cargo test --locked -p orender_engine overlay::tests -- --test-threads=1
+      - name: Build renderer
+        working-directory: omniphony-renderer
+        run: cargo build --locked --profile release-deploy -p orender_ffi
+      - name: Package review artifact
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path out | Out-Null
+          Copy-Item omniphony-renderer/target/release-deploy/orender.dll out/
+          Copy-Item omniphony-renderer/orender_ffi/include/orender.h out/
+          Copy-Item omniphony-renderer/Cargo.lock out/
+          Copy-Item ci-config/build/feedback/patches/orender-viewport-safe-area.patch out/
+          Get-ChildItem -File -Filter 'LICENSE*' | Copy-Item -Destination out/
+          Get-ChildItem out -File | Get-FileHash -Algorithm SHA256 |
+            Select-Object Hash,Path | ConvertTo-Json | Set-Content out/SHA256.json
+      - uses: actions/upload-artifact@v6
+        with:
+          name: orender-v0.5.2-viewport-windows-x86_64
+          path: out/*
+          if-no-files-found: error
+          retention-days: 7

--- a/build/atmos/parity/prepare-winbuild.py
+++ b/build/atmos/parity/prepare-winbuild.py
@@ -38,6 +38,8 @@ shutil.copyfile(root/'build/bluray-menu/patches/0005-hdmv-overlay-video-ready.pa
                 packages/'mpv-9001-hdmv-overlay-video-ready.patch')
 shutil.copyfile(root/'build/bluray-menu/patches/0006-bluray-title-resync-hdmv-context.patch',
                 packages/'mpv-9002-bluray-title-resync-hdmv-context.patch')
+shutil.copyfile(root/'build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch',
+                packages/'mpv-9003-select-late-video-enhancement-layer.patch')
 bluray=packages/'libbluray.cmake'
 text=bluray.read_text()
 assert 'PATCH_COMMAND' not in text, 'Review existing libbluray patches before composing'
@@ -50,10 +52,14 @@ assert text.count(anchor)==1
 patch='${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9004-hdmv-extended-ig-pid.patch'
 text=text.replace(anchor,anchor+
     '    PATCH_COMMAND ${EXEC} git apply --check '+patch+'\n'
-    '        COMMAND ${EXEC} git apply '+patch+'\n',1)
+    '        COMMAND ${EXEC} git apply '+patch+'\n'
+    '        COMMAND ${EXEC} git apply --check ${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9008-hdmv-link-terminate-command-list.patch\n'
+    '        COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9008-hdmv-link-terminate-command-list.patch\n',1)
 bluray.write_text(text)
 shutil.copyfile(root/'build/bluray-menu/patches/0004-hdmv-extended-ig-pid.patch',
                 packages/'libbluray-9004-hdmv-extended-ig-pid.patch')
+shutil.copyfile(root/'build/bluray-menu/patches/0008-hdmv-link-terminate-command-list.patch',
+                packages/'libbluray-9008-hdmv-link-terminate-command-list.patch')
 # MinGW already supplies the secure CRT functions. An undefined _MSC_VER
 # must not enable libvpl's pre-2005 MSVC macros inside Windows headers.
 vpl=packages/'libvpl.cmake'

--- a/build/atmos/parity/prepare-winbuild.py
+++ b/build/atmos/parity/prepare-winbuild.py
@@ -54,7 +54,9 @@ text=text.replace(anchor,anchor+
     '    PATCH_COMMAND ${EXEC} git apply --check '+patch+'\n'
     '        COMMAND ${EXEC} git apply '+patch+'\n'
     '        COMMAND ${EXEC} git apply --check ${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9008-hdmv-link-terminate-command-list.patch\n'
-    '        COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9008-hdmv-link-terminate-command-list.patch\n',1)
+    '        COMMAND ${EXEC} git apply ${CMAKE_CURRENT_SOURCE_DIR}/libbluray-9008-hdmv-link-terminate-command-list.patch\n'
+    '        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/menu-dv-bd-source/src/libbluray/hdmv\n'
+    '        COMMAND ${CMAKE_COMMAND} -E copy <SOURCE_DIR>/src/libbluray/hdmv/hdmv_vm.c ${CMAKE_BINARY_DIR}/menu-dv-bd-source/src/libbluray/hdmv/hdmv_vm.c\n',1)
 bluray.write_text(text)
 shutil.copyfile(root/'build/bluray-menu/patches/0004-hdmv-extended-ig-pid.patch',
                 packages/'libbluray-9004-hdmv-extended-ig-pid.patch')

--- a/build/atmos/parity/source-lock.json
+++ b/build/atmos/parity/source-lock.json
@@ -22,7 +22,9 @@
     "build/bluray-menu/patches/0004-hdmv-extended-ig-pid.patch": "fd04667a1cfb6f6f893655426a6c94c9bb8bac1a6b4c7b92a1d4f3161e5369b1",
     "build/bluray-menu/patches/0005-hdmv-overlay-video-ready.patch": "4273cc9b4cccf44fc286d67f04dcc4b0e8c7abd2e226fd73ae44690745a4aed8",
     "build/bluray-menu/patches/0006-bluray-title-resync-hdmv-context.patch": "ed2375e9e95140c21bbf36fb4a22c9249c0531de41ad6876d7f6ad68f99ee3d1",
-    "build/bluray-menu/patches/ffmpeg-9005-bluray-hdmv-context.patch": "26969d733227e55c2f8385958e17ef99227609270246832ba2f66c57c2303aa1"
+    "build/bluray-menu/patches/ffmpeg-9005-bluray-hdmv-context.patch": "26969d733227e55c2f8385958e17ef99227609270246832ba2f66c57c2303aa1",
+    "build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch": "87aa097169461a68e1eda7fde7afbf31ff810b0277d38ba135af673b86dcb354",
+    "build/bluray-menu/patches/0008-hdmv-link-terminate-command-list.patch": "6292c669b404d6e3bf02c086c328676475864831724c50493e3cebb4702e9f31"
   },
   "engine_cargo_lock_sha256": "7f345c3eb818f83718300fabc03c20de1d2094f8a18d8e675febc81ba5a9442e",
   "libvpl_commit": "674d015bcb294bc39fa276e99a652ea045423e82"

--- a/build/atmos/parity/verify-source.py
+++ b/build/atmos/parity/verify-source.py
@@ -30,8 +30,9 @@ if not args.inspect_existing:
     git('am','--3way',str(here/'main-core.patch'))
     git('am','--3way',str(here.parents[2]/'build/bluray-menu/patches/0005-hdmv-overlay-video-ready.patch'))
     git('am','--3way',str(here.parents[2]/'build/bluray-menu/patches/0006-bluray-title-resync-hdmv-context.patch'))
+    git('am','--3way',str(here.parents[2]/'build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch'))
     git('am','--3way',str(here/'mpv-9100-omniphony-parity.patch'))
-assert git('rev-list','--count','HEAD').strip()=='21'
+assert git('rev-list','--count','HEAD').strip()=='22'
 assert 'Add current Omniphony renderer and ASIO' in git('log','-1','--format=%s')
 assert not git('status','--porcelain').strip()
 text=(source/'filters/f_swresample.c').read_text(encoding='utf-8')
@@ -40,7 +41,7 @@ assert 'mp_chmap_to_av_layout(&out_layout, &map_out)' in text
 assert 'VDCTRL_SET_EXTRA_HW_FRAMES' in (source/'filters/f_decoder_wrapper.h').read_text(encoding='utf-8')
 assert 'p->dl->output_latency_samples(p->renderer)' in (source/'audio/decode/ad_orender.c').read_text(encoding='utf-8')
 assert 'visible && !await_video' in (source/'player/discnav.c').read_text(encoding='utf-8')
-result={'result':'PASS','scope':'fresh exact source + 17 main patches + HDMV video-ready and title/context fixes + 28-patch renderer delta',
+result={'result':'PASS','scope':'fresh exact source + 17 main patches + HDMV video-ready, title/context and late-EL fixes + 28-patch renderer delta',
         'source':str(source),'compiled':False}
 (args.work/'verification.json').write_text(json.dumps(result,indent=2),encoding='utf-8')
 print(json.dumps(result))

--- a/build/atmos/prepare-parity-source.py
+++ b/build/atmos/prepare-parity-source.py
@@ -50,6 +50,8 @@ lock = {
         for name in ['build/bluray-menu/patches/0004-hdmv-extended-ig-pid.patch',
                      'build/bluray-menu/patches/0005-hdmv-overlay-video-ready.patch',
                      'build/bluray-menu/patches/0006-bluray-title-resync-hdmv-context.patch',
+                     'build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch',
+                     'build/bluray-menu/patches/0008-hdmv-link-terminate-command-list.patch',
                      'build/bluray-menu/patches/ffmpeg-9005-bluray-hdmv-context.patch']},
     'integration_notes': [
         '0012/0015 preserve main VDCTRL_SET_EXTRA_HW_FRAMES while adding/removing the temporary fallback enum.',

--- a/build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch
+++ b/build/bluray-menu/patches/0007-select-late-video-enhancement-layer.patch
@@ -1,0 +1,36 @@
+From d0db88377ced9f28035622f729458621fbbc8c5e Mon Sep 17 00:00:00 2001
+From: Yaozhi <yaozhi@users.noreply.github.com>
+Date: Sat, 12 Sep 2026 22:20:11 +0800
+Subject: [PATCH] player: select enhancement layer discovered after disc
+ navigation
+
+---
+ player/loadfile.c | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/player/loadfile.c b/player/loadfile.c
+index 6223ca2..89cd4b9 100644
+--- a/player/loadfile.c
++++ b/player/loadfile.c
+@@ -1639,8 +1639,19 @@ void update_vo_chain_el_pair(struct MPContext *mpctx)
+     if (!mpctx->vo_chain || !mpctx->vo_chain->filter)
+         return;
+     struct track *track = mpctx->current_track[0][STREAM_VIDEO];
+-    mp_output_chain_set_el_stream(mpctx->vo_chain->filter,
+-        track ? sh_stream_dependent_sibling(track->stream) : NULL);
++    struct sh_stream *el = track
++        ? sh_stream_dependent_sibling(track->stream) : NULL;
++    // A disc menu may select the base stream before the feature introduces
++    // its dependent layer. Selecting the base earlier cannot select a group
++    // that did not exist yet. Enable the new sibling before its decoder can
++    // read an unselected stream and latch EOF.
++    if (el && track->demuxer && demux_stream_is_selected(track->stream) &&
++        !demux_stream_is_selected(el))
++    {
++        MP_VERBOSE(mpctx, "Selecting newly available video enhancement layer\n");
++        demuxer_select_track(track->demuxer, el, MP_NOPTS_VALUE, true);
++    }
++    mp_output_chain_set_el_stream(mpctx->vo_chain->filter, el);
+ }
+ 
+ void update_lavfi_complex(struct MPContext *mpctx)

--- a/build/bluray-menu/patches/0008-hdmv-link-terminate-command-list.patch
+++ b/build/bluray-menu/patches/0008-hdmv-link-terminate-command-list.patch
@@ -1,0 +1,15 @@
+--- a/src/libbluray/hdmv/hdmv_vm.c
++++ b/src/libbluray/hdmv/hdmv_vm.c
+@@ -684,6 +684,12 @@
+         BD_DEBUG(DBG_HDMV, "link_at(mark %d)\n", playmark);
+         _queue_event(p, HDMV_EVENT_PLAY_PM, playmark);
+     }
++
++    /* LinkPI/LinkMK end the interactive command list. Running commands
++     * after the link can overwrite its destination (for example, a fallback
++     * JumpTitle restarts the feature instead of playing the selected mark).
++     * Let the normal termination path emit IG_END and release the object. */
++    p->pc = 1 << 17;
+ 
+     return 0;
+ }

--- a/build/bluray-menu/tests/verify-menu-dv-state.py
+++ b/build/bluray-menu/tests/verify-menu-dv-state.py
@@ -1,0 +1,106 @@
+"""Compile actual changed C functions against small deterministic state fixtures."""
+import argparse
+from pathlib import Path
+import subprocess
+import json
+
+p=argparse.ArgumentParser()
+p.add_argument('--mpv-source',type=Path,required=True)
+p.add_argument('--bd-source',type=Path,required=True)
+p.add_argument('--cc',default='cc')
+p.add_argument('--zig',action='store_true')
+p.add_argument('--work',type=Path,required=True)
+a=p.parse_args();a.work.mkdir(parents=True,exist_ok=True)
+def function(text, signature):
+    start=text.index(signature);brace=text.index('{',start);depth=1;i=brace+1
+    while depth:
+        depth+=(text[i]=='{')-(text[i]=='}');i+=1
+    return text[start:i]
+load=(a.mpv_source/'player/loadfile.c').read_text(encoding='utf-8')
+bd=(a.bd_source/'src/libbluray/hdmv/hdmv_vm.c').read_text(encoding='utf-8')
+video=r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#define MP_NOPTS_VALUE -1e20
+#define STREAM_VIDEO 0
+#define MP_VERBOSE(...) ((void)0)
+struct sh_stream { bool selected, absent; struct sh_stream *el; };
+struct track { struct sh_stream *stream; void *demuxer; };
+struct vo { void *filter; };
+struct MPContext { struct vo *vo_chain; struct track *current_track[1][1]; };
+static int selections,pairs;static struct sh_stream *paired;
+static bool demux_stream_is_selected(struct sh_stream *s) {return s->selected;}
+static struct sh_stream *sh_stream_dependent_sibling(struct sh_stream *s) {
+ return s && s->el && !s->el->absent ? s->el : NULL;
+}
+static void demuxer_select_track(void *d,struct sh_stream *s,double t,bool on) {
+ assert(d && t==MP_NOPTS_VALUE && on);s->selected=on;selections++;
+}
+static void mp_output_chain_set_el_stream(void *f,struct sh_stream *el) {
+ assert(f);pairs++;paired=el;
+}
+'''+function(load,'void update_vo_chain_el_pair(')+r'''
+int main(void) {
+ struct sh_stream el={0},bl={.selected=true};
+ struct track track={.stream=&bl,.demuxer=&bl};
+ struct vo vo={.filter=&bl};struct MPContext c={.vo_chain=&vo,.current_track={{&track}}};
+ update_vo_chain_el_pair(&c);assert(!paired && !selections);
+ bl.el=&el;update_vo_chain_el_pair(&c);assert(paired==&el && el.selected && selections==1);
+ update_vo_chain_el_pair(&c);assert(selections==1);
+ el.absent=true;update_vo_chain_el_pair(&c);assert(!paired && selections==1);
+ el.absent=false;el.selected=false;update_vo_chain_el_pair(&c);assert(el.selected && selections==2);
+ bl.selected=false;el.selected=false;update_vo_chain_el_pair(&c);assert(!el.selected && selections==2);
+ c.current_track[0][0]=NULL;update_vo_chain_el_pair(&c);assert(!paired);
+ c.current_track[0][0]=&track;track.stream=NULL;update_vo_chain_el_pair(&c);assert(!paired);
+ int before=pairs;c.vo_chain=NULL;update_vo_chain_el_pair(&c);assert(pairs==before);
+ c.vo_chain=&vo;vo.filter=NULL;update_vo_chain_el_pair(&c);assert(pairs==before);
+ puts("video selection: 10 cases PASS");return 0;
+}
+'''
+vm=r'''
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#define BD_DEBUG(...) ((void)0)
+#define MAX_LOOP 1000
+enum {HDMV_EVENT_NONE,HDMV_EVENT_PLAY_PI,HDMV_EVENT_PLAY_PM,HDMV_EVENT_END,HDMV_EVENT_IG_END};
+typedef struct {int event,param;} HDMV_EVENT;
+typedef struct {uint32_t num_cmds;} OBJECT;
+typedef struct {OBJECT *object,*ig_object;uint32_t pc;HDMV_EVENT pending;int kind,value,jumps,freed;} HDMV_VM;
+static void _queue_event(HDMV_VM *p,int event,int param) {assert(!p->pending.event);p->pending=(HDMV_EVENT){event,param};}
+static int _get_event(HDMV_VM *p,HDMV_EVENT *ev) {
+ *ev=p->pending;p->pending=(HDMV_EVENT){0};return ev->event ? 0 : -1;
+}
+static void _free_ig_object(HDMV_VM *p) {p->ig_object=NULL;p->freed++;}
+'''+function(bd,'static int _link_at(')+r'''
+static int _hdmv_step(HDMV_VM *p) {
+ if (!p->pc) _link_at(p,p->kind==1?p->value:-1,p->kind==2?p->value:-1);
+ else p->jumps++;
+ p->pc++;return 0;
+}
+'''+function(bd,'static int _vm_run(')+r'''
+int main(void) {
+ for(int kind=1;kind<=2;kind++) for(int value=0;value<3;value++) {
+  OBJECT obj={2};HDMV_VM p={.object=&obj,.ig_object=&obj,.kind=kind,.value=value};HDMV_EVENT ev={0};
+  assert(_vm_run(&p,&ev)==0 && ev.event==(kind==1?HDMV_EVENT_PLAY_PI:HDMV_EVENT_PLAY_PM) && ev.param==value);
+  assert(_vm_run(&p,&ev)==0 && ev.event==HDMV_EVENT_IG_END && !p.jumps && p.freed==1);
+ }
+ OBJECT obj={2};HDMV_VM p={.object=&obj};
+ assert(_link_at(&p,1,-1)==-1 && !p.pc && !p.pending.event);
+ assert(_link_at(&p,-1,1)==-1 && !p.pc && !p.pending.event);
+ puts("HDMV command termination: 8 cases PASS");return 0;
+}
+'''
+results=[]
+for name,code in [('video',video),('hdmv',vm)]:
+    src=a.work/(name+'.c');src.write_text(code,encoding='utf-8')
+    exe=a.work/(name+'.exe')
+    cmd=[a.cc]+(['cc'] if a.zig else [])+['-std=c11','-O0',str(src),'-o',str(exe)]
+    subprocess.run(cmd,check=True,timeout=180)
+    proc=subprocess.run([str(exe.resolve())],capture_output=True,text=True,timeout=10)
+    results.append({'name':name,'exit':proc.returncode,'stdout':proc.stdout,'stderr':proc.stderr})
+    print(proc.stdout,proc.stderr)
+(a.work/'result.json').write_text(json.dumps(results,indent=2),encoding='utf-8')
+assert all(r['exit']==0 for r in results),results

--- a/build/feedback/patches/orender-viewport-safe-area.patch
+++ b/build/feedback/patches/orender-viewport-safe-area.patch
@@ -1,0 +1,101 @@
+--- a/omniphony-renderer/orender_engine/src/overlay.rs
++++ b/omniphony-renderer/orender_engine/src/overlay.rs
+@@ -772,6 +772,15 @@
+     1.0 - (aspect / CINEMA_ASPECT).min(1.0)
+ }
+ 
++// Reserve a border for centered labels, marker radii and diffuse trails.
++// One uniform scale is shared by ASS geometry and the BGRA field, preserving
++// the sound-space coordinates and perspective on all window aspect ratios.
++fn viewport_scale(res_x: f64, res_y: f64) -> f64 {
++    let short = res_x.min(res_y).max(1.0);
++    let margin = (short * 0.085).max(24.0);
++    (1.0 - 2.0 * margin / short).clamp(0.1, 1.0)
++}
++
+ /// Pseudo-3D front-view projection (identical to the former Lua `project_vertex`
+ /// / `project_trail_point`): X drives screen X, Z drives screen Y, Y drives the
+ /// depth-squeeze factor `s`.
+@@ -787,13 +796,14 @@
+ ) -> (f64, f64, f64) {
+     let depth_t = clamp((y + 1.0) * 0.5, 0.0, 1.0);
+     let s = 1.0 - depth_t * depth_span;
+-    let sx = cx + x * (res_x / 2.0) * s;
+-    let sy = cy - (z - 0.5) * res_y * s;
++    let inset = viewport_scale(res_x, res_y);
++    let sx = cx + x * (res_x / 2.0) * s * inset;
++    let sy = cy - (z - 0.5) * res_y * s * inset;
+     (sx, sy, s)
+ }
+ 
+ // 8 edges of the unit cube X∈{-1,+1} × Y∈{-1,+1} × Z∈{0,+1}. The Y=-1 face is
+-// omitted (its edges trace the screen border anyway).
++// omitted to retain the unobtrusive, open-front wireframe.
+ const CUBE_EDGES: [[f64; 6]; 8] = [
+     [-1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+     [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+@@ -1040,8 +1050,9 @@
+     }
+ 
+     // Display rect (front plane) and internal raster size (adaptive, capped).
+-    let dw = (res_x * s_front).round().max(1.0);
+-    let dh = (res_y * s_front).round().max(1.0);
++    let inset = viewport_scale(res_x, res_y);
++    let dw = (res_x * s_front * inset).round().max(1.0);
++    let dh = (res_y * s_front * inset).round().max(1.0);
+     let x = (cx - dw * 0.5).round();
+     let y = (cy - dh * 0.5).round();
+     let w = (dw as usize).clamp(8, FIELD_BITMAP_MAX);
+@@ -1346,8 +1357,8 @@
+     let cx = res_x / 2.0;
+     let cy = res_y / 2.0;
+     let depth_span = depth_span_for(res_x, res_y);
+-    let base_radius = (res_y * BASE_RADIUS_RATIO).max(8.0);
+-    let label_fs = (res_y * LABEL_FONT_RATIO).round().max(12.0);
++    let base_radius = (res_x.min(res_y) * BASE_RADIUS_RATIO).max(8.0);
++    let label_fs = (res_x.min(res_y) * LABEL_FONT_RATIO).round().max(12.0);
+ 
+     let mut out: Vec<String> = Vec::new();
+     // The energy heatmap is a separate BGRA bitmap overlay (built via
+@@ -1700,6 +1711,41 @@
+         assert!(ass.contains("&H6B6BFF&"), "palette colour 0 present: {ass}");
+     }
+ 
++
++    #[test]
++    fn viewport_corners_keep_labels_and_markers_inside() {
++        for (w, h) in [(1920.0,1080.0),(3840.0,2160.0),(3440.0,1440.0),
++                       (640.0,360.0),(360.0,640.0),(320.0,180.0)] {
++            let label = (w.min(h) * LABEL_FONT_RATIO).round().max(12.0);
++            let radius = (w.min(h) * BASE_RADIUS_RATIO).max(8.0) * 2.4 + 3.0;
++            for x in [-1.0,1.0] { for y in [-1.0,1.0] { for z in [0.0,1.0] {
++                let (sx,sy,_) = project(x,y,z,w/2.0,h/2.0,w,h,depth_span_for(w,h));
++                let mx = radius.max(label * 1.05 + 3.0);
++                let my = radius.max(label * 0.5 + 3.0);
++                assert!(sx >= mx && sx <= w-mx, "horizontal {w}x{h}: {sx}");
++                assert!(sy >= my && sy <= h-my, "vertical {w}x{h}: {sy}");
++            }}}
++            let (sx,sy,_) = project(0.0,0.0,0.5,w/2.0,h/2.0,w,h,depth_span_for(w,h));
++            assert_eq!((sx,sy),(w/2.0,h/2.0));
++        }
++    }
++
++    #[test]
++    fn viewport_heatmap_matches_projected_front_band() {
++        let mut s = OverlayState::default();
++        s.heatmap_enabled = true;
++        s.positions = vec![(1,0.0,0.0,0.5)];
++        s.levels.insert(1,-20.0);
++        for (w,h) in [(1920.0,1080.0),(640.0,360.0),(360.0,640.0)] {
++            let b = build_heatmap_bitmap(&s,w,h).unwrap();
++            let y = -1.0 + 1.0 / s.heatmap_bands as f64;
++            let (x0,y0,_) = project(-1.0,y,1.0,w/2.0,h/2.0,w,h,depth_span_for(w,h));
++            assert!((b.x as f64-x0).abs() <= 1.0);
++            assert!((b.y as f64-y0).abs() <= 1.0);
++            assert!(b.x > 0 && b.y > 0 && b.x+b.dw < w as i32 && b.y+b.dh < h as i32);
++        }
++    }
++
+     #[test]
+     fn center_object_projects_to_screen_centre() {
+         let _g = guard();


### PR DESCRIPTION
部分 AinanPlayer 外置代理 MKV 在切集时需要先读取文件尾 Tags 和 Cues，再回片头。现场一次约 15 秒开播等待中，这段往返占约 8.6 秒。

新增默认开启的 `demuxer-mkv-read-tail-tags` 选项。调用方可仅对慢代理按文件关闭尾部可选标签读取，使 Cues 保持按需读取；轨道、章节、附件与已有索引跳转保留。尾部自定义标签/封装统计会被省略，默认行为不变。普通/Atmos 核心共用补丁。

相对于基线，本分支也包含已单独在 #18 验证的蓝光菜单 DV 与选曲修复；该部分不作额外重构。新增真实源码抽取编译的 14 项回归，旧源码负对照失败、新源码通过，Atmos 补丁叠加检查通过。双核心构建、HTTP 延迟对照及实际 DV 回归完成前保持草稿。

构建允许 Atmos 在自身缓存缺失时复用公共主核心依赖缓存，仍执行原有源码清理、FFmpeg 静态库清理和功能验证，避免复用过期补丁结果。
